### PR TITLE
Update fpm to version 0.7.0

### DIFF
--- a/Formula/fpm.rb
+++ b/Formula/fpm.rb
@@ -1,10 +1,9 @@
 class Fpm < Formula
   desc "Fortran Package Manager (fpm)"
   homepage "https://fpm.fortran-lang.org"
-  url "https://github.com/fortran-lang/fpm/releases/download/v0.6.0/fpm-0.6.0.zip"
-  sha256 "365516f66b116a112746af043e8eccb3d854d6feb1fad0507c570433dacbf7be"
+  url "https://github.com/fortran-lang/fpm/releases/download/v0.7.0/fpm-0.7.0.zip"
+  sha256 "536dec7d4502221734683b15e6ff64a6ab3f9910df122d18f851c9a68711f91f"
   license "MIT"
-  revision 1
 
   bottle do
     root_url "https://github.com/fortran-lang/homebrew-fortran/releases/download/fpm-0.6.0_1"


### PR DESCRIPTION
New release up at https://github.com/fortran-lang/fpm/releases/tag/v0.7.0