### PR TITLE
add HOMEBREW_NO_INSTALL_FROM_API: 1 to env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Pull bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+          HOMEBREW_NO_INSTALL_FROM_API: 1
           PULL_REQUEST: ${{ github.event.pull_request.number }}
         run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
 


### PR DESCRIPTION
Solution proposed in https://github.com/orgs/Homebrew/discussions/4233 

Should fix [the current issues](https://github.com/fortran-lang/homebrew-fortran/pull/22/files#annotation_11059686461) in the pull-pr CI, apparently the fix must be in the HEAD alread, not on the same PR the pr-pull action is on

@awvwgk can you check and give me a green light?